### PR TITLE
feat(room): add Hyperlink to RoomPage header

### DIFF
--- a/Gitter/Gitter/Gitter.WindowsPhone/Views/RoomPage.xaml
+++ b/Gitter/Gitter/Gitter.WindowsPhone/Views/RoomPage.xaml
@@ -30,9 +30,12 @@
 
         <!-- Title -->
         <StackPanel Grid.Row="0">
-            <TextBlock Text="{Binding Room.Name}"
-                       Style="{ThemeResource TitleTextBlockStyle}"
-                       Margin="0 12 0 0" />
+            <HyperlinkButton NavigateUri="{Binding Room.Url}"
+                             Content="{Binding Room.Name}"
+                             Margin="0 12 0 0"
+                             FontSize="17.333"
+                             FontWeight="Bold"
+                             FontFamily="Segoe WP"/>
         </StackPanel>
 
         <!-- Content = Chat - List of messages -->


### PR DESCRIPTION
- To allow navigation to associated GitHub Page for the Room

NOTE: I have assumed here that Room.Url is the FQDN to the GitHub Repo.
I wasn't in a position to test this, since there are some compilation
errors.  If this is not the case, happy to modify.