### PR TITLE
fix(review): use WP8.x schema for store link

### DIFF
--- a/Gitter/Gitter/Gitter.Shared/Services/Concrete/RatingService.cs
+++ b/Gitter/Gitter/Gitter.Shared/Services/Concrete/RatingService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Resources;
+using Windows.ApplicationModel.Store;
 using Windows.Storage;
 using Windows.System;
 using Windows.UI.Popups;
@@ -74,11 +75,9 @@ namespace Gitter.Services.Concrete
                 // If they say yes, send them to the store
                 md.Commands.Add(new UICommand(_resourceLoader.GetString("Yes"), async command =>
                 {
-                    // Find the FamilyName of the app package
-                    string familyName = Package.Current.Id.FamilyName;
-
                     // Navigate to the store Review Page for the Application
-                    await Launcher.LaunchUriAsync(new Uri(string.Format("ms-windows-store:REVIEW?PFN={0}", familyName)));
+                    // Use the older zune schema, which works for all Windows Phone 8.x application
+                    await Launcher.LaunchUriAsync(new Uri(string.Format("ms-windows-store:reviewapp?appid=app{0}", CurrentApp.AppId)));
 
                     // Change the status to track the fact that they agreed to a review
                     ReviewedBefore = true;
@@ -103,7 +102,7 @@ namespace Gitter.Services.Concrete
             }
         }
 
-        #endregion
+#endregion
 
     }
 }


### PR DESCRIPTION
- As per the information in this StackOverflow Post:
http://stackoverflow.com/a/22979016/671491

I have been reliably informed that we can't actually test this until the application is deployed from the store.  When I test this locally, is opens an empty Review Page:

![image](https://cloud.githubusercontent.com/assets/1271146/10743607/02940cfa-7c2c-11e5-86a9-00a89d47056c.png)

Which I suspect would be populated with your actual package coming from the store.